### PR TITLE
Be more careful about running off the end of strings in `sip_method_d`.

### DIFF
--- a/libsofia-sip-ua/sip/sip_basic.c
+++ b/libsofia-sip-ua/sip/sip_basic.c
@@ -127,7 +127,7 @@ issize_t sip_request_d(su_home_t *home, sip_header_t *h, char *s, isize_t slen)
   char *uri, *version;
 
   if (msg_firstline_d(s, &uri, &version) < 0 || !uri || !version ||
-      (rq->rq_method = sip_method_d(&s, &rq->rq_method_name)) < 0 || *s ||
+      (rq->rq_method = sip_method_d(&s, &rq->rq_method_name, slen)) < 0 || *s ||
       url_d(rq->rq_url, uri) < 0 ||
       sip_version_d(&version, &rq->rq_version) < 0 || *version)
     return -1;
@@ -1205,12 +1205,15 @@ issize_t sip_cseq_d(su_home_t *home,
 {
   sip_cseq_t *cs = (sip_cseq_t *)h;
 
+  const char *start = s;
   if (msg_uint32_d(&s, &cs->cs_seq) < 0)
     return -1;
 
   if (*s) {
-    if ((cs->cs_method = sip_method_d(&s, &cs->cs_method_name)) >= 0)
+    const isize_t remaining = slen - (s - start);
+    if ((cs->cs_method = sip_method_d(&s, &cs->cs_method_name, remaining)) >= 0) {
       return 0;
+    }
   }
 
   return -1;

--- a/libsofia-sip-ua/sip/sip_prack.c
+++ b/libsofia-sip-ua/sip/sip_prack.c
@@ -96,6 +96,7 @@ SIP_HEADER_CLASS(rack, "RAck", "", ra_common, single, rack);
 
 issize_t sip_rack_d(su_home_t *home, sip_header_t *h, char *s, isize_t slen)
 {
+  const char *initial_s = s;
   sip_rack_t *ra = h->sh_rack;
 
   ra->ra_response = strtoul(s, &s, 10);
@@ -106,7 +107,8 @@ issize_t sip_rack_d(su_home_t *home, sip_header_t *h, char *s, isize_t slen)
 
     if (IS_LWS(*s)) {
       skip_lws(&s);
-      if ((ra->ra_method = sip_method_d(&s, &ra->ra_method_name)) >= 0) {
+      const isize_t skipped = s - initial_s;
+      if ((ra->ra_method = sip_method_d(&s, &ra->ra_method_name, slen - skipped)) >= 0) {
 	return 0;
       }
     }

--- a/libsofia-sip-ua/sip/sofia-sip/sip_parser.h
+++ b/libsofia-sip-ua/sip/sofia-sip/sip_parser.h
@@ -111,7 +111,7 @@ SOFIAPUBFUN isize_t sip_transport_xtra(char const *transport);
 SOFIAPUBFUN void sip_transport_dup(char **pp, char const **dd, char const *s);
 
 /* Method */
-SOFIAPUBFUN sip_method_t sip_method_d(char **ss, char const **nname);
+SOFIAPUBFUN sip_method_t sip_method_d(char **ss, char const **nname, isize_t slen);
 
 /* Call-ID */
 SOFIAPUBFUN char *sip_word_at_word_d(char **ss);


### PR DESCRIPTION
Please review this code carefully and make sure all the tests pass; I had difficulty running the test suite.

This commit has the following changes to `sip_method_d` in `sip_parser.c`, plus supporting files:

* Take the size of the input string as an argument, a pattern established by other functions.
* Use the minimum of this and the lengths of each method string, with `null` terminator subtracted, to bound `strncmp`.
* Bounds-check `n` prior to use throughout the rest of `sip_method_d`, incrementing no further than one character off the end of the input string. Without these bounds checks it was possible for malformed input to overflow the buffer; for example:

```
=================================================================
==77681==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60700000236b at pc 0x563cc24ff234 bp 0x7ffe52888f40 sp 0x7ffe52888f30
READ of size 1 at 0x60700000236b thread T0
    #0 0x563cc24ff233 in sip_method_d drachtio-server/deps/sofia-sip/libsofia-sip-ua/sip/sip_parser.c:416
    #1 0x563cc24f4c6b in sip_cseq_d drachtio-server/deps/sofia-sip/libsofia-sip-ua/sip/sip_basic.c:1212
    #2 0x563cc247c025 in header_parse drachtio-server/deps/sofia-sip/libsofia-sip-ua/msg/msg_parser.c:1132
    #3 0x563cc247b9c4 in extract_header drachtio-server/deps/sofia-sip/libsofia-sip-ua/msg/msg_parser.c:1071
    #4 0x563cc247afb5 in extract_next drachtio-server/deps/sofia-sip/libsofia-sip-ua/msg/msg_parser.c:1001

0x60700000236b is located 1 bytes to the right of 74-byte region [0x607000002320,0x60700000236a)
allocated by thread T0 here:
    #0 0x7f1faa4dcb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x563cc252f2da in sub_alloc drachtio-server/deps/sofia-sip/libsofia-sip-ua/su/su_alloc.c:541
    #2 0x563cc252fce8 in su_alloc drachtio-server/deps/sofia-sip/libsofia-sip-ua/su/su_alloc.c:960
    #3 0x563cc248257d in msg_header_alloc drachtio-server/deps/sofia-sip/libsofia-sip-ua/msg/msg_parser.c:231
```